### PR TITLE
RepoListPresenter fix

### DIFF
--- a/app/src/main/java/com/andrey7mel/testrx/presenter/RepoListPresenter.java
+++ b/app/src/main/java/com/andrey7mel/testrx/presenter/RepoListPresenter.java
@@ -65,12 +65,10 @@ public class RepoListPresenter extends BasePresenter {
     public void onCreate(Bundle savedInstanceState) {
         if (savedInstanceState != null) {
             repoList = (List<Repository>) savedInstanceState.getSerializable(BUNDLE_REPO_LIST_KEY);
-
-            if (isRepoListNotEmpty()) {
-                view.showRepoList(repoList);
-            }
         }
-
+        if (isRepoListNotEmpty()) {
+            view.showRepoList(repoList);
+        }
     }
 
     private boolean isRepoListNotEmpty() {


### PR DESCRIPTION
If list is not empty then show data in the fragment after it was restored from backstack.